### PR TITLE
Allow to parse of elements of multiple types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-## xml stream parser
+# xml stream parser
+
 xml-stream-parser is xml parser for GO. It is efficient to parse large xml data with streaming fashion.
 
-### Usage
+## Usage
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -29,10 +30,9 @@ xml-stream-parser is xml parser for GO. It is efficient to parse large xml data 
 </bookstore>
 ```
 
-<b>Stream</b> over books and journals
+**Stream** over books and journals
+
 ```go
-
-
 f, _ := os.Open("input.xml")
 br := bufio.NewReaderSize(f,65536)
 parser := xmlparser.NewXMLParser(br, "book", "journal")
@@ -44,30 +44,29 @@ for xml := range parser.Stream() {
       fmt.Println(xml.Childs["comments"][0].Childs["userComment"][0].InnerText)
    }
 }
-
 ```
 
-<b>Skip</b> tags for speed
+**Skip** tags for speed
+
 ```go
 parser := xmlparser.NewXMLParser(br, "book").SkipElements([]string{"price", "comments"})
 ```
 
-<b>Error</b> handlings
+**Error** handlings
+
 ```go
 for xml := range parser.Stream() {
-   if xml.Err !=nil { 
+   if xml.Err !=nil {
       // handle error
    }
 }
 ```
 
-<b>Progress</b> of parsing
+**Progress** of parsing
+
 ```go
 // total byte read to calculate the progress of parsing
 parser.TotalReadSize
 ```
-
-
-
 
 If you interested check also [json parser](https://github.com/tamerh/jsparser) which works similarly

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-## xml stream parser 
-xml-stream-parser is xml parser for GO. It is efficient to parse large xml data with streaming fashion. 
+## xml stream parser
+xml-stream-parser is xml parser for GO. It is efficient to parse large xml data with streaming fashion.
 
 ### Usage
 
@@ -22,23 +22,29 @@ xml-stream-parser is xml parser for GO. It is efficient to parse large xml data 
          <userComment rating="4">Excellent overview of world literature.</userComment>
       </comments>
    </book>
+   <journal>
+      <title>Journal of XML parsing</title>
+      <issue>1</issue>
+   </journal>
 </bookstore>
 ```
 
-<b>Stream</b> over books
+<b>Stream</b> over books and journals
 ```go
 
 
 f, _ := os.Open("input.xml")
 br := bufio.NewReaderSize(f,65536)
-parser := xmlparser.NewXMLParser(br, "book")
+parser := xmlparser.NewXMLParser(br, "book", "journal")
 
 for xml := range parser.Stream() {
-	fmt.Println(xml.Childs["title"][0].InnerText)
-	fmt.Println(xml.Childs["comments"][0].Childs["userComment"][0].Attrs["rating"])
-	fmt.Println(xml.Childs["comments"][0].Childs["userComment"][0].InnerText)
+   fmt.Println(xml.Childs["title"][0].InnerText)
+   if xml.Name == "book" {
+      fmt.Println(xml.Childs["comments"][0].Childs["userComment"][0].Attrs["rating"])
+      fmt.Println(xml.Childs["comments"][0].Childs["userComment"][0].InnerText)
+   }
 }
-   
+
 ```
 
 <b>Skip</b> tags for speed

--- a/xmlparser.go
+++ b/xmlparser.go
@@ -18,6 +18,7 @@ type XMLParser struct {
 }
 
 type XMLElement struct {
+	Name      string
 	Attrs     map[string]string
 	InnerText string
 	Childs    map[string][]XMLElement
@@ -69,7 +70,6 @@ func (x *XMLParser) parse() {
 
 	defer close(x.resultChannel)
 	var element *XMLElement
-	var tagName string
 	var tagClosed bool
 	var err error
 	var b byte
@@ -116,29 +116,29 @@ func (x *XMLParser) parse() {
 				continue
 			}
 
-			tagName, element, tagClosed, err = x.startElement()
+			element, tagClosed, err = x.startElement()
 
 			if err != nil {
 				x.sendError()
 				return
 			}
 
-			if tagName == x.loopElement {
+			if element.Name == x.loopElement {
 				if tagClosed {
 					x.resultChannel <- element
 					continue
 				}
 
-				element = x.getElementTree(tagName, element)
+				element = x.getElementTree(element)
 				x.resultChannel <- element
 				if element.Err != nil {
 					return
 				}
 			} else if x.skipOuterElements {
 
-				if _, ok := x.skipElements[tagName]; ok && !tagClosed {
+				if _, ok := x.skipElements[element.Name]; ok && !tagClosed {
 
-					err = x.skipElement(tagName)
+					err = x.skipElement(element.Name)
 					if err != nil {
 						x.sendError()
 						return
@@ -154,7 +154,7 @@ func (x *XMLParser) parse() {
 
 }
 
-func (x *XMLParser) getElementTree(tagName string, result *XMLElement) *XMLElement {
+func (x *XMLParser) getElementTree(result *XMLElement) *XMLElement {
 
 	if result.Err != nil {
 		return result
@@ -166,7 +166,6 @@ func (x *XMLParser) getElementTree(tagName string, result *XMLElement) *XMLEleme
 	var element *XMLElement
 	var tagClosed bool
 	x.scratch2.reset() // this hold the inner text
-	var tagName2 string
 	var iscomment bool
 
 	for {
@@ -219,7 +218,7 @@ func (x *XMLParser) getElementTree(tagName string, result *XMLElement) *XMLEleme
 					return result
 				}
 
-				if tag == tagName {
+				if tag == result.Name {
 					if len(result.Childs) == 0 {
 						result.InnerText = string(x.scratch2.bytes())
 					}
@@ -229,15 +228,15 @@ func (x *XMLParser) getElementTree(tagName string, result *XMLElement) *XMLEleme
 				x.unreadByte()
 			}
 
-			tagName2, element, tagClosed, err = x.startElement()
+			element, tagClosed, err = x.startElement()
 
 			if err != nil {
 				result.Err = err
 				return result
 			}
 
-			if _, ok := x.skipElements[tagName2]; ok && !tagClosed {
-				err = x.skipElement(tagName2)
+			if _, ok := x.skipElements[element.Name]; ok && !tagClosed {
+				err = x.skipElement(element.Name)
 				if err != nil {
 					result.Err = err
 					return result
@@ -245,18 +244,18 @@ func (x *XMLParser) getElementTree(tagName string, result *XMLElement) *XMLEleme
 				continue
 			}
 			if !tagClosed {
-				element = x.getElementTree(tagName2, element)
+				element = x.getElementTree(element)
 			}
 
-			if _, ok := result.Childs[tagName2]; ok {
-				result.Childs[tagName2] = append(result.Childs[tagName2], *element)
+			if _, ok := result.Childs[element.Name]; ok {
+				result.Childs[element.Name] = append(result.Childs[element.Name], *element)
 			} else {
 				var childs []XMLElement
 				childs = append(childs, *element)
 				if result.Childs == nil {
 					result.Childs = map[string][]XMLElement{}
 				}
-				result.Childs[tagName2] = childs
+				result.Childs[element.Name] = childs
 			}
 
 		} else {
@@ -302,7 +301,7 @@ func (x *XMLParser) skipElement(elname string) error {
 	}
 }
 
-func (x *XMLParser) startElement() (string, *XMLElement, bool, error) {
+func (x *XMLParser) startElement() (*XMLElement, bool, error) {
 
 	x.scratch.reset()
 
@@ -313,26 +312,27 @@ func (x *XMLParser) startElement() (string, *XMLElement, bool, error) {
 	// a tag have 3 forms * <abc > ** <abc type="foo" val="bar"/> *** <abc />
 	var attr string
 	var attrVal string
-	var tagName string
 	for {
 
 		cur, err = x.readByte()
 
 		if err != nil {
-			return "", nil, false, x.defaultError()
+			return nil, false, x.defaultError()
 		}
 
 		if x.isWS(cur) {
-			tagName = string(x.scratch.bytes())
+			result.Name = string(x.scratch.bytes())
 			x.scratch.reset()
 			goto search_close_tag
 		}
 
 		if cur == '>' {
 			if prev == '/' {
-				return string(x.scratch.bytes()[:len(x.scratch.bytes())-1]), result, true, nil
+				result.Name = string(x.scratch.bytes()[:len(x.scratch.bytes())-1])
+				return result, true, nil
 			}
-			return string(x.scratch.bytes()), result, false, nil
+			result.Name = string(x.scratch.bytes())
+			return result, false, nil
 		}
 		x.scratch.add(cur)
 		prev = cur
@@ -344,7 +344,7 @@ search_close_tag:
 		cur, err = x.readByte()
 
 		if err != nil {
-			return "", nil, false, x.defaultError()
+			return nil, false, x.defaultError()
 		}
 
 		if x.isWS(cur) {
@@ -359,17 +359,17 @@ search_close_tag:
 			cur, err = x.readByte()
 
 			if err != nil {
-				return "", nil, false, x.defaultError()
+				return nil, false, x.defaultError()
 			}
 
 			if !(cur == '"' || cur == '\'') {
-				return "", nil, false, x.defaultError()
+				return nil, false, x.defaultError()
 			}
 
 			attr = string(x.scratch.bytes())
 			attrVal, err = x.string(cur)
 			if err != nil {
-				return "", nil, false, x.defaultError()
+				return nil, false, x.defaultError()
 			}
 			result.Attrs[attr] = attrVal
 			x.scratch.reset()
@@ -378,9 +378,9 @@ search_close_tag:
 
 		if cur == '>' { //if tag name not found
 			if prev == '/' { //tag special close
-				return tagName, result, true, nil
+				return result, true, nil
 			}
-			return tagName, result, false, nil
+			return result, false, nil
 		}
 
 		x.scratch.add(cur)


### PR DESCRIPTION
Sometimes there are multiple types of elements in the XML file (for example OSM export - it contains nodes, ways and relations) but for parsing this the three loops through the whole file were needed.

These changes allows to specify multiple elements to parse. It should be backward compatible for any normal usage of the xml-stream-parser because there are only added item into `XMLElement` struct and changed `string` argument to `...string`.