### PR TITLE
Remove stray unreadByte from isCDATA

### DIFF
--- a/xmlparser.go
+++ b/xmlparser.go
@@ -524,7 +524,6 @@ func (x *XMLParser) isCDATA() (bool, []byte, error) {
 	}
 
 	if b[0] != '!' {
-		x.unreadByte()
 		return false, nil, nil
 	}
 


### PR DESCRIPTION
The bytes are peeked rather than read, and unreading a byte after
peeking is a questionable thing to do in the first place. Go 1.12+ makes
this a no-op, however earlier versions of Go do move the cursor back.

This makes the library work with Go 1.11 and earlier after commit
00de61485af ("Fix #8").

Fixes #13